### PR TITLE
[RELEASE] v1.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,15 @@ Changed
 - Deprecated `Notification.creation_time <https://codingame.readthedocs.io/en/latest/api.html#codingame.Notification.creation_time>`__ in favor of
   `Notification.date <https://codingame.readthedocs.io/en/latest/api.html#codingame.Notification.date>`__
 
+Version 1.2.1 (2021-11-06)
+--------------------------
+
+Fixed
+*****
+
+- ``ModuleNotFoundError`` of ``codingame.types`` submodule when importint
+  ``codingame``.
+
 Version 1.2.0 (2021-11-04)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Version 1.2.1 (2021-11-06)
 Fixed
 *****
 
-- ``ModuleNotFoundError`` of ``codingame.types`` submodule when importint
+- ``ModuleNotFoundError`` of ``codingame.types`` submodule when importing
   ``codingame``.
 
 Version 1.2.0 (2021-11-04)

--- a/codingame/__init__.py
+++ b/codingame/__init__.py
@@ -11,12 +11,13 @@ VersionInfo = NamedTuple(
     "VersionInfo", major=int, minor=int, micro=int, releaselevel=str, serial=int
 )
 
-version_info = VersionInfo(major=1, minor=2, micro=0, releaselevel="", serial=0)
+version_info = VersionInfo(major=1, minor=2, micro=1, releaselevel="", serial=0)
 
 __title__ = "codingame"
 __author__ = "takos22"
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
+from . import types  # needed for including codingame.types submodule in release
 from .clash_of_code import ClashOfCode, Player
 from .client import Client
 from .codingamer import CodinGamer

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,15 @@ Changed
 - Deprecated :attr:`Notification.creation_time` in favor of
   :attr:`Notification.date`
 
+Version 1.2.1 (2021-11-06)
+--------------------------
+
+Fixed
+*****
+
+- :exc:`ModuleNotFoundError` of ``codingame.types`` submodule when importint
+  ``codingame``.
+
 Version 1.2.0 (2021-11-04)
 --------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,7 +37,7 @@ Version 1.2.1 (2021-11-06)
 Fixed
 *****
 
-- :exc:`ModuleNotFoundError` of ``codingame.types`` submodule when importint
+- :exc:`ModuleNotFoundError` of ``codingame.types`` submodule when importing
   ``codingame``.
 
 Version 1.2.0 (2021-11-04)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_packages(package) -> typing.List[str]:
     """Return root package and all sub-packages."""
 
     return [
-        dirpath
+        dirpath.replace("\\", ".")
         for dirpath, *_ in os.walk(package)
         if os.path.exists(os.path.join(dirpath, "__init__.py"))
     ]


### PR DESCRIPTION
# Version 1.2.1

## Fixed
- `ModuleNotFoundError` of `codingame.types` submodule when importing `codingame`.