### PR TITLE
[RELEASE] v1.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,15 @@ Changed
 - Deprecated `Notification.creation_time <https://codingame.readthedocs.io/en/latest/api.html#codingame.Notification.creation_time>`__ in favor of
   `Notification.date <https://codingame.readthedocs.io/en/latest/api.html#codingame.Notification.date>`__
 
+Version 1.2.3 (2021-11-07)
+--------------------------
+
+Fixed
+*****
+
+- ``ImportError`` of ``codingame.types`` submodule when importing
+  ``codingame``, the ``1.2.1`` and ``1.2.2`` fixes don't work.
+
 Version 1.2.2 (2021-11-06)
 --------------------------
 

--- a/codingame/__init__.py
+++ b/codingame/__init__.py
@@ -11,13 +11,12 @@ VersionInfo = NamedTuple(
     "VersionInfo", major=int, minor=int, micro=int, releaselevel=str, serial=int
 )
 
-version_info = VersionInfo(major=1, minor=2, micro=2, releaselevel="", serial=0)
+version_info = VersionInfo(major=1, minor=2, micro=3, releaselevel="", serial=0)
 
 __title__ = "codingame"
 __author__ = "takos22"
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
-from . import types  # needed for including codingame.types submodule in release
 from .clash_of_code import ClashOfCode, Player
 from .client import Client
 from .codingamer import CodinGamer

--- a/codingame/http/base.py
+++ b/codingame/http/base.py
@@ -1,14 +1,13 @@
 import typing
 from abc import ABC, abstractmethod
 
-if typing.TYPE_CHECKING:
-    from codingame.types import (
-        ClashOfCode,
-        CodinGamerFromID,
-        Follower,
-        Following,
-        PointsStatsFromHandle,
-    )
+from ..types import (
+    ClashOfCode,
+    CodinGamerFromID,
+    Follower,
+    Following,
+    PointsStatsFromHandle,
+)
 
 __all__ = ("BaseHTTPClient",)
 

--- a/codingame/http/base.py
+++ b/codingame/http/base.py
@@ -65,25 +65,23 @@ class BaseHTTPClient(ABC):
             "CodinGamer", "loginSite", [email, password, True, "CODINGAME", ""]
         )
 
-    def get_codingamer_from_handle(
-        self, handle: str
-    ) -> "PointsStatsFromHandle":
+    def get_codingamer_from_handle(self, handle: str) -> PointsStatsFromHandle:
         return self.request(
             "CodinGamer", "findCodingamePointsStatsByHandle", [handle]
         )
 
-    def get_codingamer_from_id(self, id: int) -> "CodinGamerFromID":
+    def get_codingamer_from_id(self, id: int) -> CodinGamerFromID:
         return self.request(
             "CodinGamer", "findCodinGamerPublicInformations", [id]
         )
 
-    def get_codingamer_followers(self, id: int) -> typing.List["Follower"]:
+    def get_codingamer_followers(self, id: int) -> typing.List[Follower]:
         return self.request("CodinGamer", "findFollowers", [id, id, None])
 
     def get_codingamer_follower_ids(self, id: int) -> typing.List[int]:
         return self.request("CodinGamer", "findFollowerIds", [id])
 
-    def get_codingamer_following(self, id: int) -> typing.List["Following"]:
+    def get_codingamer_following(self, id: int) -> typing.List[Following]:
         return self.request("CodinGamer", "findFollowing", [id, id])
 
     def get_codingamer_following_ids(self, id: int) -> typing.List[int]:
@@ -94,10 +92,10 @@ class BaseHTTPClient(ABC):
     def get_codingamer_clash_of_code_rank(self, id: int) -> int:
         return self.request("ClashOfCode", "getClashRankByCodinGamerId", [id])
 
-    def get_clash_of_code_from_handle(self, handle: str) -> "ClashOfCode":
+    def get_clash_of_code_from_handle(self, handle: str) -> ClashOfCode:
         return self.request("ClashOfCode", "findClashByHandle", [handle])
 
-    def get_pending_clash_of_code(self) -> "ClashOfCode":
+    def get_pending_clash_of_code(self) -> ClashOfCode:
         return self.request("ClashOfCode", "findPendingClashes")
 
     # Notification

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,15 @@ Changed
 - Deprecated :attr:`Notification.creation_time` in favor of
   :attr:`Notification.date`
 
+Version 1.2.3 (2021-11-07)
+--------------------------
+
+Fixed
+*****
+
+- :exc:`ImportError` of ``codingame.types`` submodule when importing
+  ``codingame``, the ``1.2.1`` and ``1.2.2`` fixes don't work.
+
 Version 1.2.2 (2021-11-06)
 --------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ addopts = --cov
 source =
     codingame
     tests
-omit = codingame/types
+omit = */types/*
 branch = True
 
 [coverage:report]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ addopts = --cov
 source =
     codingame
     tests
+omit = codingame/types
 branch = True
 
 [coverage:report]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ addopts = --cov
 source =
     codingame
     tests
-omit = */types/*
 branch = True
 
 [coverage:report]

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,7 @@ setup(
     long_description_content_type="text/x-rst",
     author="takos22",
     author_email="takos2210@gmail.com",
-    packages=[
-        "codingame",
-        "codingame.client",
-        "codingame.http",
-    ],
+    packages=get_packages("codingame"),
     python_requires=">=3.6",
     install_requires=get_requirements(),
     extras_require=extra_requires,


### PR DESCRIPTION
# Version 1.2.3

## Fixed
- `ImportError` of `codingame.types` submodule when importing `codingame`, the ``1.2.1`` and ``1.2.2`` fixes don't work.