### PR TITLE
Fix docs bug with remember_me_cookie as login param

### DIFF
--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -109,7 +109,8 @@ in on CodinGame.
 
     import codingame
 
-    client = codingame.Client(remember_me_cookie="your cookie here")
+    client = codingame.Client()
+    client.login(remember_me_cookie="your cookie here")
 
     # then you can access the logged in codingamer like this
     print(client.codingamer)


### PR DESCRIPTION
codingame.Client() doesn't have param remember_me_cookie
Update example code to pass cookie to login()

(Sorry if the PR isn't based from the right branch; I didn't see CONTRIBUTING docs about which branch the PR should merge into. Maybe it should go to 1.2.x if you are still updating that.)