### PR TITLE
Fix datetime format

### DIFF
--- a/codingame/utils.py
+++ b/codingame/utils.py
@@ -9,7 +9,8 @@ __all__ = (
     "CLASH_OF_CODE_HANDLE_REGEX",
     "validate_leaderboard_type",
     "validate_leaderboard_group",
-    "DT_FORMAT",
+    "DT_FORMAT_1",
+    "DT_FORMAT_2",
     "to_datetime",
 )
 
@@ -92,14 +93,18 @@ def validate_leaderboard_group(group: str, logged_in: bool) -> bool:
         raise LoginRequired()
 
 
-DT_FORMAT = "%b %d, %Y %I:%M:%S %p"
+DT_FORMAT_1 = "%b %d, %Y %I:%M:%S %p"
+DT_FORMAT_2 = "%b %d, %Y, %I:%M:%S %p"  # see issue #23
 
 
 def to_datetime(data: typing.Optional[typing.Union[int, str]]) -> datetime:
     if isinstance(data, int):
         return datetime.utcfromtimestamp(data / 1000.0)
     elif isinstance(data, str):
-        return datetime.strptime(data, DT_FORMAT)
+        try:
+            return datetime.strptime(data, DT_FORMAT_1)
+        except ValueError:
+            return datetime.strptime(data, DT_FORMAT_2)
     elif data is None:
         return None
     else:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ autoflake~=1.4
 black~=22.6
 doc8~=0.9
 flake8~=3.9
+importlib-metadata~=4.13
 isort~=5.8
 pytest~=6.2
 pytest-asyncio~=0.16.0


### PR DESCRIPTION
## Bug description
CodinGame changed their datetime format, which caused `Client.get_pending_clash_of_codes()` to error.
Described in issue #23.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If classes/methods/attributes were added/changed then they have been documented and tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the tests to support the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new class, method or attribute).
- [ ] This PR is a breaking change (e.g. classes, methods, attributes or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] The code follows the style guidelines and passes linting and testing.